### PR TITLE
Refactor: Add context to email Send, standardize naming

### DIFF
--- a/email/cmd/email/main.go
+++ b/email/cmd/email/main.go
@@ -96,7 +96,7 @@ func main() {
 		}()
 
 		wg.Add(1)
-		go messageConsumer.AwaitMessages(partitionConsumer, partition, done, &wg)
+		go messageConsumer.ConsumeMessages(partitionConsumer, partition, done, &wg)
 	}
 
 	wg.Wait()

--- a/email/internal/email/email.go
+++ b/email/internal/email/email.go
@@ -1,11 +1,13 @@
 package email
 
 import (
+	"context"
+
 	"github.com/sirupsen/logrus"
 )
 
 type Sender interface {
-	Send(emailAddress, orderID string) error
+	Send(ctx context.Context, emailAddress, orderID string) error
 }
 
 type EmailSender struct {
@@ -18,9 +20,9 @@ func NewEmailSender(logger *logrus.Logger) *EmailSender {
 	}
 }
 
-func (e *EmailSender) Send(emailAddress, orderID string) error {
+func (e *EmailSender) Send(ctx context.Context, emailAddress, orderID string) error {
 	// Implement actual email sending logic here
-	// For now, just log the action
+	// For now, just log the action. Use ctx for tracing in the future.
 	e.Logger.Infof("Sending email to %s about order %s", emailAddress, orderID)
 	return nil
 }

--- a/ledger/cmd/ledger/consumer.go
+++ b/ledger/cmd/ledger/consumer.go
@@ -87,7 +87,7 @@ func main() {
 		}
 	}()
 
-	ledgerConsumer := ledger.NewLedgerConsumer(tracer, mySqlConn, consumer, logger)
+	ledgerConsumer := ledger.NewMessageConsumer(tracer, mySqlConn, consumer, logger)
 
 	partitions, err := ledgerConsumer.Consumer.Partitions(topic)
 	if err != nil {
@@ -107,7 +107,7 @@ func main() {
 		}()
 
 		wg.Add(1)
-		go ledgerConsumer.AwaitMessages(partitionConsumer, partition, &wg, done)
+		go ledgerConsumer.ConsumeMessages(partitionConsumer, partition, &wg, done)
 	}
 	wg.Wait()
 }

--- a/ledger/internal/ledger/ledger.go
+++ b/ledger/internal/ledger/ledger.go
@@ -21,7 +21,7 @@ type LedgerMsg struct {
 	Date                 string `json:"date"`
 }
 
-type LedgerConsumer struct {
+type MessageConsumer struct {
 	tracer     trace.Tracer
 	propagator propagation.TextMapPropagator
 	db         db.LedgerRepository
@@ -29,8 +29,8 @@ type LedgerConsumer struct {
 	logger     *logrus.Logger
 }
 
-func NewLedgerConsumer(tracer trace.Tracer, db db.LedgerRepository, consumer sarama.Consumer, logger *logrus.Logger) *LedgerConsumer {
-	return &LedgerConsumer{
+func NewMessageConsumer(tracer trace.Tracer, db db.LedgerRepository, consumer sarama.Consumer, logger *logrus.Logger) *MessageConsumer {
+	return &MessageConsumer{
 		tracer:     tracer,
 		propagator: propagation.TraceContext{},
 		db:         db,
@@ -39,44 +39,44 @@ func NewLedgerConsumer(tracer trace.Tracer, db db.LedgerRepository, consumer sar
 	}
 }
 
-func (l *LedgerConsumer) AwaitMessages(partitionConsumer sarama.PartitionConsumer, partition int32, wg *sync.WaitGroup, done chan struct{}) {
+func (mc *MessageConsumer) ConsumeMessages(partitionConsumer sarama.PartitionConsumer, partition int32, wg *sync.WaitGroup, done chan struct{}) {
 	defer wg.Done()
 	for {
 		select {
 		case msg := <-partitionConsumer.Messages():
-			l.logger.Infof("Partition %d: Received message", partition)
-			l.consumeMessage(msg)
+			mc.logger.Infof("Partition %d: Received message", partition)
+			mc.processMessage(msg)
 		case <-done:
-			l.logger.Infof("Received Done signal. Partition %d: Shutting down consumer", partition)
+			mc.logger.Infof("Received Done signal. Partition %d: Shutting down consumer", partition)
 			return
 		}
 	}
 }
 
-func (l *LedgerConsumer) consumeMessage(msg *sarama.ConsumerMessage) {
+func (mc *MessageConsumer) processMessage(msg *sarama.ConsumerMessage) {
 	// Extract trace context from Kafka headers
 	carrier := propagation.MapCarrier{}
 	for _, h := range msg.Headers {
 		carrier[string(h.Key)] = string(h.Value)
 	}
 	ctx := context.Background()
-	ctx = l.propagator.Extract(ctx, carrier)
+	ctx = mc.propagator.Extract(ctx, carrier)
 
-	ctx, span := l.tracer.Start(ctx, "consumeMessage")
+	ctx, span := mc.tracer.Start(ctx, "processMessage")
 	defer span.End()
 
 	var ledgerlMsg LedgerMsg
 	if err := json.Unmarshal(msg.Value, &ledgerlMsg); err != nil {
-		l.logger.Error("Error unmarshalling message: ", err)
+		mc.logger.Error("Error unmarshalling message: ", err)
 		span.RecordError(err)
 		return
 	}
-	l.logger.Debugf("LedgerMsg unmarshalled: %+v", ledgerlMsg)
-	err := l.db.Insert(ctx, ledgerlMsg.OrderID, ledgerlMsg.CustomerEmailAddress, ledgerlMsg.Amount, ledgerlMsg.Operation, ledgerlMsg.Date)
+	mc.logger.Debugf("LedgerMsg unmarshalled: %+v", ledgerlMsg)
+	err := mc.db.Insert(ctx, ledgerlMsg.OrderID, ledgerlMsg.CustomerEmailAddress, ledgerlMsg.Amount, ledgerlMsg.Operation, ledgerlMsg.Date)
 	if err != nil {
-		l.logger.Error("Error inserting ledger message: ", err)
+		mc.logger.Error("Error inserting ledger message: ", err)
 		span.RecordError(err)
 		return
 	}
-	l.logger.Infof("Ledger message inserted for order %s, customer email %s", ledgerlMsg.OrderID, ledgerlMsg.CustomerEmailAddress)
+	mc.logger.Infof("Ledger message inserted for order %s, customer email %s", ledgerlMsg.OrderID, ledgerlMsg.CustomerEmailAddress)
 }


### PR DESCRIPTION
- Updated email Send method to accept context for tracing.
- Standardized consumer and message processing naming in email and ledger services.